### PR TITLE
Adds a config setting to deny players with no previous experience

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -514,3 +514,11 @@
 /datum/config_entry/string/discord_guildid
 
 /datum/config_entry/string/discord_roleid
+
+// A time based allowlist, this only allows clients who have the required number
+// of hours as a living player on the servers linked to the database this server
+// is linked to. Clients without the appropriate hours are disconnected with a
+// message about playing more on other db linked servers
+/datum/config_entry/flag/allowlist_previous_players
+
+/datum/config_entry/number/allowlist_previous_hours_count

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -366,6 +366,24 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			to_chat(src, "Sorry, but the web client is restricted to byond members only.")
 			qdel(src)
 			return 0
+	
+	//Config that only allows players with previous play experience, requires a database to track
+	//living hours in the first place
+	if(CONFIG_GET(flag/allowlist_previous_players))
+		// check for living hours requirement
+		var/required_living_minutes = CONFIG_GET(number/allowlist_previous_hours_count) * 60
+		var/living_minutes = src.get_exp_living(TRUE)
+		if(required_living_minutes <= 0)
+			stack_trace("You have set the experienced players allow list on, but have not set a minimum hours requirement, this is not a valid configuration")
+			qdel(src)
+			return 0
+		
+		if(living_minutes < required_living_minutes)
+			to_chat(src, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
+				+ "playtime on tg servers to play on this server. You have [living_minutes] minutes. Play more!</span>")
+			qdel(src)
+			return 0
+
 
 	if( (world.address == address || !address) && !GLOB.host )
 		GLOB.host = key

--- a/config/config.txt
+++ b/config/config.txt
@@ -527,3 +527,9 @@ REQUIRED_LIVING_HOURS 0
 
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
+
+## Uncomment to require previous living hours on the servers to join this server
+#ALLOWLIST_PREVIOUS_PLAYERS
+
+## Set how many living hours are required to join this server
+ALLOWLIST_PREVIOUS_HOURS_COUNT 0


### PR DESCRIPTION
Adds a configuration options that allows denying users who haven't
gained a requiured amount of living hours on the server previously

This can be used to reduce grief from alt and unused accounts during
major events and or having servers that only have players who have
demonstrated an ability to play over a longer period and not acquire any
bans
