### PR TITLE
 Ensure the exp data is loaded before checking time counts 

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -370,17 +370,23 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	//Config that only allows players with previous play experience, requires a database to track
 	//living hours in the first place
 	if(CONFIG_GET(flag/allowlist_previous_players))
-		// check for living hours requirement
-		var/required_living_minutes = CONFIG_GET(number/allowlist_previous_hours_count) * 60
-		var/living_minutes = src.get_exp_living(TRUE)
-		if(required_living_minutes <= 0)
-			stack_trace("You have set the experienced players allow list on, but have not set a minimum hours requirement, this is not a valid configuration")
-			qdel(src)
+		//Make sure the users exp is loaded
+		if(src.set_exp_from_db())
+			// check for living hours requirement
+			var/required_living_minutes = CONFIG_GET(number/allowlist_previous_hours_count) * 60
+			var/living_minutes = src.get_exp_living(TRUE)
+			if(required_living_minutes <= 0)
+				to_chat(src, "Administrators have set the experienced players allow list on, but have not set a minimum hours requirement, this is not a valid configuration")
+				qdel(src)
 			return 0
 		
-		if(living_minutes < required_living_minutes)
-			to_chat(src, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
-				+ "playtime on tg servers to play on this server. You have [living_minutes] minutes. Play more!</span>")
+			if(living_minutes < required_living_minutes)
+				to_chat(src, "<span class='warning'>You must have at least [required_living_minutes] minutes of living " \
+					+ "playtime on tg servers to play on this server. You have [living_minutes] minutes. Play more!</span>")
+				qdel(src)
+				return 0
+		else
+			to_chat(src, "The experienced players allow list is configured, but is not setup correctly and user exp cannot be loaded")
 			qdel(src)
 			return 0
 


### PR DESCRIPTION
We have to do this work to ensure that we actually have living hours to check.

Note, if a user connects before the DB connection and subsystem is alive, they will be booted.