### PR TITLE
Prophunt projectors, win and lose conditions, poki mane poggers sex, and more!

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -178,3 +178,26 @@
 /obj/effect/dummy/chameleon/Destroy()
 	master.disrupt(0)
 	return ..()
+
+//prophunt projectors (disrupt while seekers are seeking = booted)
+/obj/item/chameleon/prophunt
+	var/obj/machinery/computer/arena/prophunt/gamemaster = null //if this doesn't get set by new, we want it to runtime.
+
+/obj/item/chameleon/prophunt/Initialize(mapload, arenacomputer)
+	. = ..()
+	gamemaster = arenacomputer
+
+/obj/item/chameleon/prophunt/disrupt(delete_dummy)
+	var/caught = FALSE
+	if(active_dummy)
+		if(gamemaster.gamestate == PROPHUNT_GAME)
+			for(var/mob/M in active_dummy)
+				to_chat(M, "<span class='userdanger'>You've been caught!</span>")
+				caught = TRUE
+	. = ..()
+	if(caught)
+		for(var/mob/M in active_dummy)
+			gamemaster.kick_hider_out(M)
+	gamemaster.projectors -= src //don't want them out of the game using their funny little projector and losing twice or some wack stuff
+	//and no, "objects_delete_on_leaving_arena" var doesn't help. that's only for arenas it loads, not equipment for players.
+	qdel(src)

--- a/code/modules/prophunt/prophunt.dm
+++ b/code/modules/prophunt/prophunt.dm
@@ -196,11 +196,10 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 
 /obj/machinery/computer/arena/prophunt/proc/conclude_round(seekers_win = FALSE)//bool
 	QDEL_LIST(projectors)
-	for(var/mob/M in total_players)
-		if(seekers_win)
-			to_chat(M, "<span class='redtext'>SEEKERS HAVE WON! ALL HIDERS HAVE BEEN CAUGHT!")
-		else
-			to_chat(M, "<span class='greentext'>HIDERS HAVE WON! NOT ALL HIDERS WERE CAUGHT!")
+	if(seekers_win)
+		to_chat(total_players, "<span class='redtext'>SEEKERS HAVE WON! ALL HIDERS HAVE BEEN CAUGHT!")
+	else
+		to_chat(total_players, "<span class='greentext'>HIDERS HAVE WON! NOT ALL HIDERS WERE CAUGHT!")
 	kick_players_out()
 	if(next_stage_timer)
 		deltimer(next_stage_timer)
@@ -208,10 +207,8 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 	try_autostart()
 
 /obj/machinery/computer/arena/prophunt/proc/kick_hider_out(var/mob/player)//used for when you get caught
-	for(var/mob/M in hiders)
-		if(M == player)
-			M.forceMove(get_landmark_turf(ARENA_EXIT))
-			hiders -= M
+	player.forceMove(get_landmark_turf(ARENA_EXIT))
+		hiders -= player
 	if(!hiders.len)
 		conclude_round(seekers_win = TRUE)
 

--- a/code/modules/prophunt/prophunt.dm
+++ b/code/modules/prophunt/prophunt.dm
@@ -31,7 +31,6 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 		if(GLOB.directory[key] && GLOB.directory[key].mob == game_q[key])
 			. += 1
 
-
 //flush to remove from signups
 /datum/minigame_signups/proc/GetPlayers(game_id,count,flush=TRUE)
 	var/result = list()
@@ -99,8 +98,9 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 	var/auto = FALSE //Toggle to start autogame
 	var/game_state = PROPHUNT_SIGNUPS
 	var/list/projectors = list()
-	var/list/hiders = list()
+	var/list/hiders = list() //NOT A TRUE LIST AFTER GAME STARTS, AS HIDERS WILL GET REMOVED FROM THIS LIST
 	var/list/searchers = list()
+	var/list/total_players = list() //people can get kicked out of hiders, lowering the amount of people still in the game. They will want to know if they won or not though, so here's everyone who played
 
 	var/hider_count = 5
 	var/searcher_count = 1
@@ -145,7 +145,7 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 	switch(special_value)
 		if("end_prophunt_round")
 			auto = FALSE
-			conclude_round()
+			conclude_round(seekers_win = FALSE) //round timed out without all hiders gone, so hiders win
 			return TRUE
 		else
 			return FALSE
@@ -156,24 +156,27 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 	if(!filtered_keys)
 		return
 	game_state = PROPHUNT_SETUP
+	total_players = list()
 	hiders = list()
 	for(var/i in 1 to hider_count)
 		var/chosen_key = pick(filtered_keys)
 		var/chosen_mob = filtered_keys[chosen_key]
 		filtered_keys -= chosen_key
 		hiders += chosen_mob
+		total_players += chosen_mob
 	searchers = list()
 	for(var/i in 1 to searcher_count)
 		var/chosen_key = pick(filtered_keys)
 		var/chosen_mob = filtered_keys[chosen_key]
 		filtered_keys -= chosen_key
 		searchers += chosen_mob
+		total_players += chosen_mob
 	load_random_arena()
 	send_hiders_in()
 
 /obj/machinery/computer/arena/prophunt/proc/send_hiders_in()
 	for(var/mob/living/L in hiders)
-		var/obj/item/chameleon/projector = new()
+		var/obj/item/chameleon/prophunt/projector = new(null,src)
 		projectors += projector
 		L.forceMove(get_landmark_turf(PROPHUNT_HIDER_SPAWN))
 		L.put_in_hands(projector)
@@ -185,24 +188,37 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 /obj/machinery/computer/arena/prophunt/proc/send_searchers_in()
 	for(var/mob/living/L in searchers)
 		L.forceMove(get_landmark_turf(PROPHUNT_SEARCHER_SPAWN))
-	to_chat(searchers,"<span class='danger'>Search! You got 3 minutes!</span>")
+	to_chat(searchers,"<span class='danger'>Search! You got 3 minutes! Catching a hider will boot them out of the game!</span>")
 	to_chat(hiders,"<span class='userdanger'>Search started! Try to stay hidden for 3 minutes!</span>")
+	to_chat(hiders,"<span class='userdanger'>WARNING: IF YOUR PROJECTOR GETS DISRUPTED BY THIS POINT, YOU WILL BE COUNTED AS CAUGHT AND BOOTED OUT!</span>")
 	game_state = PROPHUNT_GAME
 	next_stage_timer = addtimer(CALLBACK(src,.proc/conclude_round),search_time, TIMER_STOPPABLE)
 
-/obj/machinery/computer/arena/prophunt/proc/conclude_round()
+/obj/machinery/computer/arena/prophunt/proc/conclude_round(seekers_win = FALSE)//bool
 	QDEL_LIST(projectors)
+	for(var/mob/M in total_players)
+		if(seekers_win)
+			to_chat(M, "<span class='redtext'>SEEKERS HAVE WON! ALL HIDERS HAVE BEEN CAUGHT!")
+		else
+			to_chat(M, "<span class='greentext'>HIDERS HAVE WON! NOT ALL HIDERS WERE CAUGHT!")
 	kick_players_out()
 	if(next_stage_timer)
 		deltimer(next_stage_timer)
 	game_state = PROPHUNT_SIGNUPS
 	try_autostart()
 
+/obj/machinery/computer/arena/prophunt/proc/kick_hider_out(var/mob/player)//used for when you get caught
+	for(var/mob/M in hiders)
+		if(M == player)
+			M.forceMove(get_landmark_turf(ARENA_EXIT))
+			hiders -= M
+	if(!hiders.len)
+		conclude_round(seekers_win = TRUE)
+
 /obj/machinery/computer/arena/prophunt/kick_players_out()
 	for(var/mob/M in hiders+searchers)
 		M.forceMove(get_landmark_turf(ARENA_EXIT))
 	. = ..()
-
 
 /obj/effect/landmark/arena/prophunt
 	arena_id = "prophunt_arena"

--- a/code/modules/prophunt/prophunt.dm
+++ b/code/modules/prophunt/prophunt.dm
@@ -31,6 +31,7 @@ GLOBAL_DATUM_INIT(minigame_signups,/datum/minigame_signups,new)
 		if(GLOB.directory[key] && GLOB.directory[key].mob == game_q[key])
 			. += 1
 
+
 //flush to remove from signups
 /datum/minigame_signups/proc/GetPlayers(game_id,count,flush=TRUE)
 	var/result = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

there's a special prophunt version of the projectors given now that have the arena computer saved. if the arena computer say the seekers are searching for hiders, disrupting the camo will boot you out of the game. when all hiders are booted, seekers win. if seekers cannot boot everyone before time is up, hiders win.

## Why It's Good For The Game

well prophunt was kinda like "i got you now i must beat you in a fistfight" but for every single guy you're seeking like jfc

