### PR TITLE
Even more mafia improvements

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -474,6 +474,22 @@
 /datum/outfit/syndicate_empty/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
 
+/datum/outfit/syndicate_empty/mafia
+	name = "Syndicate Operative Mafia"
+	uniform = /obj/item/clothing/under/syndicate
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
+
+/datum/outfit/syndicate_empty/mafia/post_equip(mob/living/carbon/human/H)
+	var/list/no_drops = list()
+	no_drops += H.get_item_by_slot(ITEM_SLOT_FEET)
+	no_drops += H.get_item_by_slot(ITEM_SLOT_ICLOTHING)
+	no_drops += H.get_item_by_slot(ITEM_SLOT_GLOVES)
+	for(var/i in no_drops)
+		var/obj/item/I = i
+		ADD_TRAIT(I, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+
+
 /obj/effect/mob_spawn/human/syndicate/battlecruiser
 	name = "Syndicate Battlecruiser Ship Operative"
 	short_desc = "You are a crewmember aboard the syndicate flagship: the SBC Starfury."

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -196,6 +196,10 @@
 		I.add_mob_blood(H)
 	H.regenerate_icons()
 
+/datum/outfit/psycho/mafia
+	r_hand = null
+	head = null
+
 /datum/outfit/assassin
 	name = "Assassin"
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -36,3 +36,6 @@
 	box = /obj/item/storage/box/survival/medical
 
 	chameleon_extras = /obj/item/gun/syringe
+
+/datum/outfit/job/doctor/mafia
+	l_hand = null

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -149,9 +149,11 @@
 				if(MAFIA_TEAM_TOWN)
 					alive_town++
 				if(MAFIA_TEAM_SOLO)
+					if(R.solo_counts_as_town)
+						alive_town++
 					solos_to_ask += R
 
-	///PHASE TWO: SEND STATS TO SOLO ANTAGS, SEE IF THEY WON OR TOWNS CAN'T WIN
+	///PHASE TWO: SEND STATS TO SOLO ANTAGS, SEE IF THEY WON OR TEAMS CANNOT WIN
 
 	for(var/datum/mafia_role/solo in solos_to_ask)
 		if(solo.check_total_victory(alive_town, alive_mafia))
@@ -178,6 +180,9 @@
 /datum/mafia_controller/proc/start_the_end(message)
 	if(message)
 		send_message(message)
+	for(var/datum/mafia_role/R in all_roles)
+		R.reveal_role(src)
+		R.body.Stun(INFINITY,ignore_canstun = TRUE)//so they don't grief the area around them with their outfit
 	phase = MAFIA_PHASE_VICTORY_LAP
 	next_phase_timer = addtimer(CALLBACK(src,.proc/end_game),victory_lap_period,TIMER_STOPPABLE)
 
@@ -373,7 +378,9 @@
 					deltimer(next_phase_timer)
 					tc.InvokeAsync()
 				return TRUE
-	if(!user_role)
+	if(!user_role)//ghosts
+		return
+	if(user_role.game_status == MAFIA_DEAD)//dead people?
 		return
 	//User actions
 	switch(action)
@@ -407,7 +414,6 @@
 			if(phase != MAFIA_PHASE_JUDGEMENT)
 				return
 			to_chat(user_role.body,"Your vote on [on_trial.body.real_name] submitted as INNOCENT!")
-			//
 			judgement_innocent_votes -= user_role//no double voting
 			judgement_guilty_votes -= user_role//no radical centrism
 			judgement_innocent_votes += user_role

--- a/code/modules/mafia/map_pieces.dm
+++ b/code/modules/mafia/map_pieces.dm
@@ -81,7 +81,7 @@
 
 /obj/mafia_game_signup/debug
 	var/datum/mafia_controller/MF
-	var/list/debug_setup = list(/datum/mafia_role/md=1,/datum/mafia_role/fugitive=1,/datum/mafia_role/detective=1,/datum/mafia_role/mafia=1)
+	var/list/debug_setup = list(/datum/mafia_role/md=1,/datum/mafia_role/obsessed=1,/datum/mafia_role/detective=1,/datum/mafia_role/mafia=1)
 
 /obj/mafia_game_signup/debug/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Roles can now be revealed, when the game ends everyone's role is revealed and it also reveals the role of people who get lynched
no more voting as dead people!
fugitives can no longer waste charges of their power at night!
aaand evil solos (not traitor) now count as townies for mafia win. you must have a majority over both evil solos and townies to win, mafia!


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
