### PR TITLE
Disable keyLoop() for non-staff ghosts after pop limit

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,5 +1,5 @@
 #define EVENTMODE ///Special compiler flag that turns on the event mode
-#define EVENTMODE_OPTIMIZE_POP 75 //Required for EVENTMODE, amount of clients before keyLoop() resrictions for ghosts kick in
+#define EVENTMODE_OPTIMIZE_POP 75 //Required for EVENTMODE, max amount of clients before drastic performance "enhancements" kick in
 /*
 List of things this does
 1) all tiles have planetary atmos of a breathable human mix

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,11 +1,12 @@
 #define EVENTMODE ///Special compiler flag that turns on the event mode
 /*
 List of things this does
-1) all tiles have planetary atmos of a breathable human mix
-2) planetary atmos shares 10 x faster
-3) all areas have non dynamic lighting
-4) all cleanables schedule a 30 second qdel on creation
-5) all vending machines are free
+- all tiles have planetary atmos of a breathable human mix
+- planetary atmos shares 10 x faster
+- all areas have non dynamic lighting
+- all cleanables schedule a 30 second qdel on creation
+- all vending machines are free
+- non admin ghosts lose basic movement and change_view_range, tray_view verbs
 */
 //#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,5 @@
 #define EVENTMODE ///Special compiler flag that turns on the event mode
+#define EVENTMODE_OPTIMIZE_POP 75 //Required for EVENTMODE, amount of clients before keyLoop() resrictions for ghosts kick in
 /*
 List of things this does
 1) all tiles have planetary atmos of a breathable human mix

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,12 +1,11 @@
 #define EVENTMODE ///Special compiler flag that turns on the event mode
 /*
 List of things this does
-- all tiles have planetary atmos of a breathable human mix
-- planetary atmos shares 10 x faster
-- all areas have non dynamic lighting
-- all cleanables schedule a 30 second qdel on creation
-- all vending machines are free
-- non admin ghosts lose basic movement and change_view_range, tray_view verbs
+1) all tiles have planetary atmos of a breathable human mix
+2) planetary atmos shares 10 x faster
+3) all areas have non dynamic lighting
+4) all cleanables schedule a 30 second qdel on creation
+5) all vending machines are free
 */
 //#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -36,4 +36,8 @@ SUBSYSTEM_DEF(input)
 
 /datum/controller/subsystem/input/fire()
 	for(var/mob/user as anything in GLOB.player_list)
+		#ifdef EVENTMODE
+		if(user.stat == DEAD && !user.client?.holder)
+			continue // ignore dead mobs, say hotkey still works and so do ghost clicks
+		#endif
 		user.focus?.keyLoop(user.client)

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(input)
 /datum/controller/subsystem/input/fire()
 	for(var/mob/user as anything in GLOB.player_list)
 		#ifdef EVENTMODE
-		if(user.stat == DEAD && !user.client?.holder)
+		if(TGS_CLIENT_COUNT > EVENTMODE_OPTIMIZE_POP && user.stat == DEAD && !user.client?.holder)
 			continue // ignore dead mobs, say hotkey still works and so do ghost clicks
 		#endif
 		user.focus?.keyLoop(user.client)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -977,7 +977,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	. = ..()
 	#ifdef EVENTMODE
 	if(!client?.holder)
-		notransform = TRUE
+		to_chat(src, "<span class='hierophant'>Spectator ghost keybinds are disabled for the event.\nPlease use Orbit, Jump, and Teleport to look around.</span>")
 		remove_verb(src, list(
 			/mob/dead/observer/verb/change_view_range,
 			/mob/dead/observer/verb/add_view_range,

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -972,3 +972,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			client.images += t_ray_images
 		else
 			client.images -= stored_t_ray_images
+
+/mob/dead/observer/Login()
+	. = ..()
+	#ifdef EVENTMODE
+	if(!client?.holder)
+		notransform = TRUE
+		remove_verb(src, list(
+			/mob/dead/observer/verb/change_view_range,
+			/mob/dead/observer/verb/add_view_range,
+			/mob/dead/observer/proc/tray_view,
+			))
+	#endif

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -977,7 +977,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	. = ..()
 	#ifdef EVENTMODE
 	if(!client?.holder)
-		to_chat(src, "<span class='hierophant'>Spectator ghost keybinds are disabled for the event.\nPlease use Orbit, Jump, and Teleport to look around.</span>")
+		to_chat(src, "<span class='hierophant'>Observer keybinds [TGS_CLIENT_COUNT > EVENTMODE_OPTIMIZE_POP ? "are" : "may later be"] disabled for the event.\nPlease use Orbit, Jump, and Teleport to look around.</span>")
 		remove_verb(src, list(
 			/mob/dead/observer/verb/change_view_range,
 			/mob/dead/observer/verb/add_view_range,

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -76,6 +76,9 @@
 	var/turf/T = get_turf(src)
 	if(mind && mind.name && mind.active && !istype(T.loc, /area/ctf))
 		deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
+		#ifdef EVENTMODE
+		ghostize(TRUE) // ghost them so they don't have to manually use the verb with keyLoop() disabled
+		#endif
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)
 	set_drugginess(0)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -77,7 +77,7 @@
 	if(mind && mind.name && mind.active && !istype(T.loc, /area/ctf))
 		deadchat_broadcast(" has died at <b>[get_area_name(T)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 		#ifdef EVENTMODE
-		ghostize(TRUE) // ghost them so they don't have to manually use the verb with keyLoop() disabled
+		ghostize(TRUE) // ghost them so they don't have to manually use the verb with keyLoop() possibly disabled
 		#endif
 	if(mind)
 		mind.store_memory("Time of death: [tod]", 0)


### PR DESCRIPTION
also disables zoom for non-staff ghosts, and adds a login message for new ghosts to ignore about their limited mobility during the event, and automatically ghosts living mobs when they die since they won't be able to move with wasd which would usually ghostize for them