### PR TITLE
Give Arena Team / Antag HUDs to all mobs

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -409,6 +409,20 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		to_chat(src, span_notice("You will no longer examine things you click on."))
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Ghost Inquisitiveness", "[prefs.inquisitive_ghost ? "Enabled" : "Disabled"]"))
 
+#ifdef EVENTMODE
+/client/verb/toggle_team_huds() //shameless copy from admin verbs
+	set name = "Toggle Team/Antag HUD"
+	set desc = "Toggles whether you see Arena Team and Antagonist HUDs"
+	set category = "Preferences"
+
+	var/adding_hud = !has_antag_hud()
+
+	for(var/datum/atom_hud/antag/H in GLOB.huds)
+		adding_hud ? H.add_hud_to(usr) : H.remove_hud_from(usr)
+
+	to_chat(usr, "Team HUDs [adding_hud ? "enabled" : "disabled"].")
+#endif
+
 //Admin Preferences
 /client/proc/toggleadminhelpsound()
 	set name = "Hear/Silence Adminhelps"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -94,6 +94,12 @@
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 	client.init_verbs()
 
+	#ifdef EVENTMODE
+	if(!isnewplayer(src)) //skip newplayers so no lobby huds or runtimes when they get deleted, might be too hot here?
+		for(var/datum/atom_hud/antag/H in GLOB.huds)
+			H.add_hud_to(src) //enable antag/team huds by default
+	#endif
+
 	return TRUE
 
 


### PR DESCRIPTION
Perhaps we could get away with just using the `/datum/atom_hud/antag/teamhud` types, but this way it'll still work if we end up adding more antag derived event huds too.