### PR TITLE
More mob nerfs, misc fixes

### DIFF
--- a/_maps/map_files/debug/Cooking Round (2.3) 64x64.dmm
+++ b/_maps/map_files/debug/Cooking Round (2.3) 64x64.dmm
@@ -29,7 +29,7 @@
 "ai" = (
 /obj/effect/portal/permanent/red/farm/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "al" = (
 /obj/structure/sink/kitchen{
@@ -138,7 +138,9 @@
 /turf/open/floor/cult,
 /area/awaymission/centcom_away/thunderdome)
 "bc" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/clothing/under/rank/civilian/chef,
 /obj/item/clothing/under/rank/civilian/chef/skirt,
 /obj/item/clothing/suit/apron/chef,
@@ -187,7 +189,7 @@
 	dir = 8;
 	max_integrity = 9999
 	},
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
@@ -318,7 +320,7 @@
 /turf/open/floor/iron/dark,
 /area/awaymission/centcom_away/thunderdome)
 "cu" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
@@ -332,7 +334,9 @@
 /turf/open/floor/stone,
 /area/awaymission/centcom_away/thunderdome)
 "cC" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -340,12 +344,11 @@
 	pixel_y = 5
 	},
 /obj/item/food/grown/holymelon,
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
 "cL" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 9999
 	},
@@ -374,7 +377,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "cQ" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -414,7 +419,10 @@
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
-/obj/structure/closet/crate/wooden,
+/obj/structure/closet/crate/wooden{
+	anchorable = 0;
+	anchored = 1
+	},
 /obj/item/food/grown/wheat,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/item/clothing/gloves/botanic_leather,
@@ -529,7 +537,10 @@
 /area/awaymission/centcom_away/thunderdome)
 "dW" = (
 /obj/item/food/grown/wheat,
-/obj/structure/closet/crate/wooden,
+/obj/structure/closet/crate/wooden{
+	anchorable = 0;
+	anchored = 1
+	},
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
@@ -678,12 +689,12 @@
 "fc" = (
 /obj/effect/portal/permanent/blue/lavaland/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "fg" = (
 /obj/effect/portal/permanent/blue/grocery/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "fi" = (
 /obj/item/food/grown/ash_flora/mushroom_stem,
@@ -713,7 +724,7 @@
 "fL" = (
 /obj/effect/portal/permanent/blue/zoo/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "fN" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -814,6 +825,8 @@
 /area/awaymission/centcom_away/thunderdome)
 "gR" = (
 /obj/structure/beebox,
+/obj/item/reagent_containers/honeycomb,
+/obj/item/reagent_containers/honeycomb,
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "gU" = (
@@ -854,7 +867,9 @@
 /turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "hh" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -960,7 +975,9 @@
 /turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "hQ" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1025,7 +1042,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "ip" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1329,7 +1348,7 @@
 "kj" = (
 /obj/effect/portal/permanent/red/hospital/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "kk" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -1383,7 +1402,7 @@
 "kE" = (
 /obj/effect/portal/permanent/red/zoo/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "kF" = (
 /obj/effect/portal/permanent/green/hospital/from,
@@ -1432,10 +1451,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
-"kP" = (
-/mob/living/simple_animal/hostile/gorilla,
-/turf/open/floor/plating/grass/jungle,
-/area/awaymission/centcom_away/thunderdome)
 "kR" = (
 /obj/structure/alien/weeds,
 /obj/item/xenos_claw,
@@ -1481,7 +1496,9 @@
 /turf/open/floor/pod,
 /area/awaymission/centcom_away/thunderdome)
 "le" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/food/grown/cherries{
 	pixel_x = -5
 	},
@@ -1495,7 +1512,9 @@
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
 "lf" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/food/grown/berries/glow{
 	pixel_y = 7
 	},
@@ -1570,14 +1589,16 @@
 "lx" = (
 /obj/effect/portal/permanent/green/zoo/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "lz" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "lE" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/suit/wizrobe,
 /obj/item/clothing/suit/wizrobe,
@@ -1597,7 +1618,7 @@
 "lM" = (
 /obj/effect/portal/permanent/green/farm/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "lT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1717,6 +1738,12 @@
 /obj/machinery/computer/bookmanagement,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
+/area/awaymission/centcom_away/thunderdome)
+"mJ" = (
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "mL" = (
 /obj/structure/sink/kitchen{
@@ -1880,7 +1907,7 @@
 	},
 /area/awaymission/centcom_away/thunderdome)
 "nF" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/machinery/door/window/survival_pod,
 /turf/open/floor/pod,
 /area/awaymission/centcom_away/thunderdome)
@@ -1911,7 +1938,7 @@
 /turf/open/water,
 /area/awaymission/centcom_away/thunderdome)
 "nT" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 9999
 	},
@@ -1952,7 +1979,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/centcom_away/thunderdome)
 "oy" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
@@ -2024,7 +2051,9 @@
 /turf/open/floor/grass/fakebasalt,
 /area/awaymission/centcom_away/thunderdome)
 "oQ" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -2063,7 +2092,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "pa" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -2110,7 +2141,9 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "pp" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -2124,7 +2157,6 @@
 /obj/item/food/grown/citrus/orange{
 	pixel_x = 6
 	},
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -2380,7 +2412,9 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "qX" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -2518,7 +2552,7 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "rE" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 9999
 	},
@@ -2574,7 +2608,9 @@
 /turf/open/floor/plating,
 /area/awaymission/centcom_away/thunderdome)
 "rV" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -2582,7 +2618,6 @@
 	pixel_y = 5
 	},
 /obj/item/food/grown/watermelon,
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -2695,7 +2730,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "sU" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -2732,7 +2769,9 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "sZ" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/clothing/shoes/sneakers/black,
 /obj/item/clothing/shoes/wheelys,
 /obj/item/clothing/under/rank/civilian/mime,
@@ -2753,7 +2792,7 @@
 	},
 /area/awaymission/centcom_away/thunderdome)
 "tc" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "tf" = (
@@ -2764,7 +2803,9 @@
 /turf/closed/indestructible/riveted,
 /area/awaymission/centcom_away/thunderdome)
 "th" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/clothing/shoes/clown_shoes,
 /obj/item/clothing/shoes/clown_shoes/jester,
 /obj/item/clothing/suit/chaplainsuit/clownpriest,
@@ -2856,7 +2897,7 @@
 	},
 /area/awaymission/centcom_away/thunderdome)
 "tW" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
@@ -2928,7 +2969,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/centcom_away/thunderdome)
 "ur" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
@@ -2997,7 +3038,7 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "vh" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /turf/open/floor/plating/dirt/dark,
 /area/awaymission/centcom_away/thunderdome)
 "vn" = (
@@ -3068,6 +3109,13 @@
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
+/area/awaymission/centcom_away/thunderdome)
+"vN" = (
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/obj/structure/holosign/barrier/ctf/green,
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "vP" = (
 /mob/living/simple_animal/crab{
@@ -3303,7 +3351,9 @@
 /turf/open/floor/iron/white,
 /area/awaymission/centcom_away/thunderdome)
 "wV" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -3355,7 +3405,9 @@
 /turf/open/floor/plating/dirt/dark,
 /area/awaymission/centcom_away/thunderdome)
 "xo" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -3385,7 +3437,9 @@
 /turf/open/floor/pod,
 /area/awaymission/centcom_away/thunderdome)
 "xy" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -3409,7 +3463,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "xF" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/machinery/door/airlock,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -3446,7 +3500,7 @@
 "xS" = (
 /obj/effect/portal/permanent/green/jungle/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "xV" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3654,7 +3708,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "zp" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "zA" = (
@@ -3845,7 +3899,7 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "AV" = (
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/machinery/door/window/survival_pod{
 	dir = 1
 	},
@@ -3989,7 +4043,9 @@
 /turf/open/floor/plating/grass/jungle,
 /area/awaymission/centcom_away/thunderdome)
 "BY" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -4055,7 +4111,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "Cy" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -4082,7 +4140,9 @@
 /turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "CK" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/clothing/under/rank/civilian/janitor/maid,
 /obj/item/clothing/accessory/maidapron,
 /obj/item/organ/tail/cat,
@@ -4196,7 +4256,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "Dr" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
@@ -4236,7 +4296,7 @@
 "DH" = (
 /obj/effect/portal/permanent/red/grocery/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "DI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -4294,7 +4354,7 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "Ed" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -4378,7 +4438,7 @@
 "ES" = (
 /obj/effect/portal/permanent/green/hospital/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "EU" = (
 /obj/structure/trap/ctf/blue,
@@ -4388,7 +4448,7 @@
 "EV" = (
 /obj/effect/portal/permanent/blue/farm/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "Fa" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -4415,7 +4475,9 @@
 /turf/open/floor/plating/grass/jungle,
 /area/awaymission/centcom_away/thunderdome)
 "Fh" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -4514,7 +4576,7 @@
 /turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "FL" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 9999
 	},
@@ -4532,7 +4594,9 @@
 /turf/open/floor/plating/grass/jungle,
 /area/awaymission/centcom_away/thunderdome)
 "FS" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -4572,7 +4636,7 @@
 	dir = 8;
 	max_integrity = 9999
 	},
-/obj/structure/trap/ctf/green,
+/obj/structure/holosign/barrier/ctf/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth_large,
 /area/awaymission/centcom_away/thunderdome)
@@ -4710,7 +4774,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "Hu" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -4720,7 +4786,6 @@
 /obj/item/food/grown/grapes{
 	pixel_x = 5
 	},
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -4958,7 +5023,7 @@
 "Je" = (
 /obj/effect/portal/permanent/red/lavaland/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "Jg" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -4975,7 +5040,9 @@
 /turf/open/floor/holofloor/beach/water,
 /area/awaymission/centcom_away/thunderdome)
 "Jm" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -5025,7 +5092,9 @@
 /turf/open/floor/pod,
 /area/awaymission/centcom_away/thunderdome)
 "JF" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -5191,7 +5260,7 @@
 /turf/open/floor/plating/dirt/dark,
 /area/awaymission/centcom_away/thunderdome)
 "KS" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/machinery/door/airlock,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -5263,7 +5332,7 @@
 "Lw" = (
 /obj/effect/portal/permanent/blue/hospital/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "Lx" = (
 /obj/machinery/computer/operating{
@@ -5307,7 +5376,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "LI" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -5450,7 +5521,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "MA" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -5591,10 +5664,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/awaymission/centcom_away/thunderdome)
-"MZ" = (
-/mob/living/simple_animal/hostile/gorilla,
-/turf/open/water,
 /area/awaymission/centcom_away/thunderdome)
 "Nd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5780,7 +5849,9 @@
 /turf/closed/indestructible/reinforced,
 /area/awaymission/centcom_away/thunderdome)
 "Ov" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -5800,7 +5871,9 @@
 /turf/open/floor/plating/dirt/dark,
 /area/awaymission/centcom_away/thunderdome)
 "OG" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -5813,7 +5886,6 @@
 /obj/item/food/grown/citrus/lemon{
 	pixel_x = -5
 	},
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -5954,7 +6026,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /turf/open/floor/stone,
 /area/awaymission/centcom_away/thunderdome)
 "PE" = (
@@ -6012,6 +6084,11 @@
 /turf/open/floor/mineral/titanium/tiled/white{
 	color = "#4AC948"
 	},
+/area/awaymission/centcom_away/thunderdome)
+"Qe" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/structure/holosign/barrier/ctf/green,
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "Qh" = (
 /obj/structure/table/wood/fancy,
@@ -6182,7 +6259,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "Rg" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/clothing/under/pants/black{
 	pixel_y = -4
 	},
@@ -6314,7 +6393,7 @@
 "RS" = (
 /obj/effect/portal/permanent/green/lavaland/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "RT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6354,7 +6433,7 @@
 "Sr" = (
 /obj/effect/portal/permanent/green/grocery/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "Su" = (
 /obj/structure/table/wood,
@@ -6438,10 +6517,6 @@
 /obj/item/food/grown/mushroom/amanita,
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
-"SZ" = (
-/obj/structure/beebox/premade,
-/turf/open/floor/plating/grass,
-/area/awaymission/centcom_away/thunderdome)
 "Te" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -6467,10 +6542,12 @@
 "Tj" = (
 /obj/effect/portal/permanent/red/jungle/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "Tk" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/food/grown/berries{
 	pixel_y = 6
 	},
@@ -6493,12 +6570,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/dirt/dark,
 /area/awaymission/centcom_away/thunderdome)
-"Tt" = (
-/mob/living/simple_animal/hostile/bear/russian{
-	faction = list("jungle")
-	},
-/turf/open/water,
-/area/awaymission/centcom_away/thunderdome)
 "TB" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
@@ -6506,7 +6577,9 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "TF" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -6519,7 +6592,6 @@
 /obj/item/food/grown/citrus/lime{
 	pixel_x = -5
 	},
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -6592,7 +6664,7 @@
 "Uk" = (
 /obj/effect/portal/permanent/blue/jungle/toward,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
 "Ul" = (
 /obj/structure/sign/poster/contraband/space_cola,
@@ -6638,7 +6710,9 @@
 /turf/open/floor/carpet/green,
 /area/awaymission/centcom_away/thunderdome)
 "Uw" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/item/food/grown/bluecherries{
 	pixel_x = -5
 	},
@@ -6670,7 +6744,9 @@
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
 "Uz" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -6680,7 +6756,6 @@
 /obj/item/food/grown/grapes/green{
 	pixel_x = 6
 	},
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -6981,7 +7056,9 @@
 /turf/open/floor/plating/grass,
 /area/awaymission/centcom_away/thunderdome)
 "WK" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -7001,7 +7078,7 @@
 /turf/open/floor/plating/sandy_dirt,
 /area/awaymission/centcom_away/thunderdome)
 "WQ" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
@@ -7081,7 +7158,9 @@
 /turf/closed/indestructible/fakeglass,
 /area/awaymission/centcom_away/thunderdome)
 "Xy" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -7175,6 +7254,13 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/engine,
 /area/awaymission/centcom_away/thunderdome)
+"Yc" = (
+/mob/living/simple_animal/hostile/gorilla{
+	desc = "This 'rilla is a straight killa. Due to budget cuts he rolls solo.";
+	name = "Junior"
+	},
+/turf/open/water,
+/area/awaymission/centcom_away/thunderdome)
 "Yd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -7204,12 +7290,14 @@
 /turf/open/floor/holofloor/beach/water,
 /area/awaymission/centcom_away/thunderdome)
 "Yt" = (
-/obj/structure/trap/ctf/red,
+/obj/structure/holosign/barrier/ctf/red,
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/centcom_away/thunderdome)
 "YA" = (
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -7420,7 +7508,9 @@
 /area/awaymission/centcom_away/thunderdome)
 "ZJ" = (
 /obj/effect/decal/cleanable/blood,
-/obj/structure/rack,
+/obj/structure/rack{
+	max_integrity = 9999
+	},
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -7432,7 +7522,6 @@
 /obj/item/food/grown/apple{
 	pixel_x = 8
 	},
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/awaymission/centcom_away/thunderdome)
@@ -8100,7 +8189,7 @@ Xs
 lx
 uQ
 jk
-tW
+vN
 uA
 zQ
 ju
@@ -8298,7 +8387,7 @@ Xs
 lM
 uQ
 jk
-oy
+Qe
 Cc
 zQ
 ju
@@ -9264,7 +9353,7 @@ YL
 iw
 ri
 jG
-SZ
+gR
 Fy
 Fy
 Fy
@@ -9991,7 +10080,7 @@ iw
 ri
 eU
 iw
-cM
+mJ
 cM
 Sf
 NL
@@ -10386,7 +10475,7 @@ KP
 KP
 mb
 ri
-Az
+Yc
 VB
 VB
 Az
@@ -10398,7 +10487,7 @@ BU
 ng
 RK
 BU
-kP
+BU
 dZ
 Az
 Az
@@ -10717,7 +10806,7 @@ Vg
 mb
 ri
 Az
-Tt
+Az
 BU
 BU
 Lf
@@ -11574,7 +11663,7 @@ Jb
 Jb
 sV
 ri
-MZ
+Az
 Az
 JS
 BU

--- a/_maps/map_files/debug/Cooking Round (2.3) 64x64.dmm
+++ b/_maps/map_files/debug/Cooking Round (2.3) 64x64.dmm
@@ -226,7 +226,7 @@
 "bK" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/door/window/southright,
-/obj/structure/closet/secure_closet/freezer/money{
+/obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
 	},
 /obj/item/clothing/head/crown,
@@ -308,7 +308,8 @@
 /area/awaymission/centcom_away/thunderdome)
 "cq" = (
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/closed/indestructible/fakeglass,
 /area/awaymission/centcom_away/thunderdome)
@@ -418,6 +419,13 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/item/clothing/gloves/botanic_leather,
 /obj/item/clothing/under/pants/youngfolksjeans,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
 /turf/open/floor/vault/sandstone,
 /area/awaymission/centcom_away/thunderdome)
 "dm" = (
@@ -522,8 +530,6 @@
 "dW" = (
 /obj/item/food/grown/wheat,
 /obj/structure/closet/crate/wooden,
-/obj/item/food/grown/wheat,
-/obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
 /obj/item/food/grown/wheat,
@@ -674,14 +680,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine/air,
 /area/awaymission/centcom_away/thunderdome)
-"fd" = (
-/obj/machinery/button/door/directional/south{
-	id = "green_shutter";
-	name = "green shutter control";
-	req_access_txt = "16"
-	},
-/turf/open/floor/iron/dark,
-/area/awaymission/centcom_away/thunderdome)
 "fg" = (
 /obj/effect/portal/permanent/blue/grocery/toward,
 /obj/effect/turf_decal/bot,
@@ -823,7 +821,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -900,7 +899,8 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -1177,6 +1177,14 @@
 "jk" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron,
+/area/awaymission/centcom_away/thunderdome)
+"jl" = (
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/button/door/directional{
+	id = "blue_shutter";
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
 /area/awaymission/centcom_away/thunderdome)
 "jo" = (
 /obj/item/food/fishmeat/armorfish,
@@ -1518,7 +1526,9 @@
 /area/awaymission/centcom_away/thunderdome)
 "ll" = (
 /obj/structure/railing{
-	dir = 6
+	climbable = 0;
+	dir = 6;
+	max_integrity = 9999
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -1776,7 +1786,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -2327,7 +2338,8 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -2592,9 +2604,11 @@
 "sa" = (
 /obj/structure/statue/silver/medborg{
 	anchored = 1;
+	desc = "Yell at coderbus.";
 	dir = 1;
 	icon = 'icons/obj/bike.dmi';
-	icon_state = "speedbike_red"
+	icon_state = "speedbike_red";
+	name = "Speedbike"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/centcom_away/thunderdome)
@@ -2675,7 +2689,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -3025,7 +3040,9 @@
 /area/awaymission/centcom_away/thunderdome)
 "vC" = (
 /obj/structure/railing{
-	dir = 10
+	climbable = 0;
+	dir = 10;
+	max_integrity = 9999
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -3141,7 +3158,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/door/window/southleft,
-/obj/structure/closet/secure_closet/freezer/money{
+/obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
 	},
 /obj/item/clothing/head/crown,
@@ -3166,7 +3183,9 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	dir = 6
+	climbable = 0;
+	dir = 6;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -3258,6 +3277,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/documents,
 /turf/open/floor/iron,
+/area/awaymission/centcom_away/thunderdome)
+"wO" = (
+/obj/structure/table/wood/fancy/green,
+/obj/machinery/button/door/directional{
+	id = "green_shutter";
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
 /area/awaymission/centcom_away/thunderdome)
 "wP" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -3439,7 +3466,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -3520,14 +3548,6 @@
 "yE" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/mineral/titanium/survival/pod,
-/area/awaymission/centcom_away/thunderdome)
-"yH" = (
-/obj/machinery/button/door/directional/south{
-	id = "red_shutter";
-	name = "red shutter control";
-	req_access_txt = "16"
-	},
-/turf/open/floor/iron/dark,
 /area/awaymission/centcom_away/thunderdome)
 "yK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3956,7 +3976,9 @@
 /area/awaymission/centcom_away/thunderdome)
 "BT" = (
 /obj/structure/railing{
-	dir = 10
+	climbable = 0;
+	dir = 10;
+	max_integrity = 9999
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -4020,7 +4042,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -4080,7 +4103,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -4664,7 +4688,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -5466,7 +5491,8 @@
 /area/awaymission/centcom_away/thunderdome)
 "MF" = (
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -5475,7 +5501,8 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -5492,7 +5519,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -5715,6 +5743,14 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
+/area/awaymission/centcom_away/thunderdome)
+"Oa" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/button/door/directional{
+	id = "red_shutter";
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
 /area/awaymission/centcom_away/thunderdome)
 "Od" = (
 /obj/item/food/grown/bungofruit,
@@ -6216,7 +6252,8 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	climbable = 0
+	climbable = 0;
+	max_integrity = 9999
 	},
 /turf/open/floor/iron,
 /area/awaymission/centcom_away/thunderdome)
@@ -6789,7 +6826,9 @@
 /area/awaymission/centcom_away/thunderdome)
 "Vy" = (
 /obj/structure/railing{
-	dir = 6
+	climbable = 0;
+	dir = 6;
+	max_integrity = 9999
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -6991,14 +7030,6 @@
 	},
 /obj/item/food/canned_jellyfish,
 /turf/open/floor/pod,
-/area/awaymission/centcom_away/thunderdome)
-"WT" = (
-/obj/machinery/button/door/directional/south{
-	id = "blue_shutter";
-	name = "blue shutter control";
-	req_access_txt = "16"
-	},
-/turf/open/floor/iron/dark,
 /area/awaymission/centcom_away/thunderdome)
 "WW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7206,7 +7237,9 @@
 /area/awaymission/centcom_away/thunderdome)
 "YC" = (
 /obj/structure/railing{
-	dir = 10
+	climbable = 0;
+	dir = 10;
+	max_integrity = 9999
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -8210,8 +8243,8 @@ ju
 EF
 qq
 Fm
-fd
-wA
+Ur
+wO
 mw
 "}
 (13,1,1) = {"
@@ -9530,8 +9563,8 @@ ju
 RM
 MR
 Tg
-yH
-vb
+Ur
+Oa
 LM
 "}
 (33,1,1) = {"
@@ -10850,8 +10883,8 @@ ju
 Fc
 lZ
 rL
-WT
-dV
+Ur
+jl
 yz
 "}
 (53,1,1) = {"


### PR DESCRIPTION
- Limits the jungle mobs to 1 gorilla (Junior) and I think 1 bear (maybe 2, but probably 1)
- Anchors a pair of wheat crates
- Removes the active apiaries in favour of empty apiaries with honeycombs on them. 
- Removes the high-pressure floor in the cooking areas
- Replaces the CTF spawn protection for green and red (NOT blue, because there were only two teams coded in) with provided holobarriers