### PR TITLE
Critical last minute roster fixes and functionality

### DIFF
--- a/code/__DEFINES/arena.dm
+++ b/code/__DEFINES/arena.dm
@@ -4,4 +4,4 @@
 #define ARENA_BLUE_TEAM "blue" // team3
 
 /// the delay between elimination messages
-#define BATTLE_ROYALE_ELIMINATION_VOICE_DELAY 7 SECONDS
+#define BATTLE_ROYALE_ELIMINATION_VOICE_DELAY 3 SECONDS

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -25,6 +25,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 ///Rolls for the amount of traits and adds them to the traits list
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
+	#ifdef EVENTMODE
+	return
+	#endif
 	for(var/i in subtypesof(/datum/station_trait))
 		var/datum/station_trait/trait_typepath = i
 		if(initial(trait_typepath.trait_flags) & STATION_TRAIT_ABSTRACT)

--- a/code/datums/event/_contestant.dm
+++ b/code/datums/event/_contestant.dm
@@ -95,9 +95,9 @@
 	if(!istype(our_boy))
 		return
 	if(godmode)
-		our_boy.status_traits |= GODMODE
+		our_boy.status_flags |= GODMODE
 	else
-		our_boy &= GODMODE
+		our_boy.status_flags &= ~GODMODE
 
 /// Spawn this guy in as a human at the appropriate spawnpoint. Returns TRUE if successful, so we can count off how many successfully spawn when needed
 /datum/contestant/proc/spawn_this_contestant(obj/machinery/arena_spawn/spawnpoint)
@@ -116,7 +116,8 @@
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(get_turf(spawnpoint))
 	if(oldbody?.client) // debug testing with empty contestant datums
 		oldbody.client.prefs.copy_to(M)
-	M.set_species(/datum/species/human) // Could use setting per team
+	if(!(M.dna?.species in list(/datum/species/human, /datum/species/moth, /datum/species/lizard)))
+		M.set_species(/datum/species/human) // Could use setting per team
 	M.equipOutfit(/datum/outfit/job/assistant) // TODO: ADD CONTROLS FOR THIS
 	//M.equipOutfit(outfits[team] ? outfits[team] : default_outfit)
 	//M.faction += team //In case anyone wants to add team based stuff to arena special effects

--- a/code/datums/event/_contestant.dm
+++ b/code/datums/event/_contestant.dm
@@ -116,7 +116,7 @@
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(get_turf(spawnpoint))
 	if(oldbody?.client) // debug testing with empty contestant datums
 		oldbody.client.prefs.copy_to(M)
-	if(!(M.dna?.species in list(/datum/species/human, /datum/species/moth, /datum/species/lizard)))
+	if(!(M.dna?.species in list(/datum/species/human, /datum/species/moth, /datum/species/lizard, /datum/species/human/felinid)))
 		M.set_species(/datum/species/human) // Could use setting per team
 	M.equipOutfit(/datum/outfit/job/assistant) // TODO: ADD CONTROLS FOR THIS
 	//M.equipOutfit(outfits[team] ? outfits[team] : default_outfit)

--- a/code/datums/event/_roster.dm
+++ b/code/datums/event/_roster.dm
@@ -524,7 +524,7 @@ GLOBAL_DATUM_INIT(global_roster, /datum/roster, new)
 	var/teams = prefs["team_event"]["value"] == "Yes"
 	var/divvy_teams_by_num_not_size = prefs["team_num_instead_of_size"]["value"] == "Yes"
 	var/team_divvy_factor = prefs["team_divvy_factor"]["value"]
-	var/three_team = prefs["three_team"]["value"]
+	var/three_team = prefs["three_team"]["value"] == "Yes"
 
 	three_team_round = three_team
 
@@ -606,8 +606,9 @@ GLOBAL_DATUM_INIT(global_roster, /datum/roster, new)
 /datum/roster/proc/spawn_team(mob/user, datum/event_team/spawning_team)
 	log_game("[key_name_admin(user)] has tried spawning teams!")
 
-	if(istype(spawning_team) && spawning_team.battle_royale)
+	if(battle_royale_active)
 		spawn_battle_royale(user)
+		return
 
 	if(!istype(spawning_team))
 		team1?.spawn_members(user, spawns_team1)
@@ -679,7 +680,7 @@ GLOBAL_DATUM_INIT(global_roster, /datum/roster, new)
 		return team_huds[ARENA_RED_TEAM]
 	else if(check_team == team2)
 		return team_huds[ARENA_GREEN_TEAM]
-	else if(check_team == team2)
+	else if(check_team == team3)
 		return team_huds[ARENA_BLUE_TEAM]
 
 /*

--- a/code/datums/event/_team.dm
+++ b/code/datums/event/_team.dm
@@ -43,7 +43,7 @@
 		return
 
 	new_kid.set_frozen(frozen) // are these needed?
-	new_kid.set_godmode(godmode)
+	new_kid.set_godmode(null, godmode)
 	new_kid.current_team = src
 	LAZYADD(members, new_kid)
 	testing("successfully added [new_kid] to [src]")

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -238,3 +238,23 @@
 /obj/structure/holosign/barrier/ctf/blue
 	team_allow = ARENA_BLUE_TEAM
 	icon_state = "trap-frost"
+
+// todo: seriously need to store what team key someone is on on their mob so we don't have to do all these checks
+/obj/structure/holosign/barrier/ctf/CanAllowThrough(atom/movable/mover, turf/target)
+	var/datum/roster/the_roster = GLOB.global_roster
+	if(!the_roster || !LAZYLEN(the_roster.all_contestants))
+		return TRUE
+
+	var/mob/living/carbon/carbon_mover = mover
+	if(!istype(carbon_mover) || !carbon_mover.ckey || !carbon_mover.mind)
+		return FALSE
+
+	var/datum/contestant/mover_contestant = the_roster.all_contestants[carbon_mover.ckey]
+	if(!istype(mover_contestant) || mover_contestant.eliminated)
+		return FALSE
+
+	var/datum/event_team/mover_team = mover_contestant.current_team
+	if(!istype(mover_team) || the_roster.get_team_slot(mover_team) != team_allow)
+		return FALSE
+
+	return TRUE

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -336,6 +336,10 @@
 
 /// Allows us to roll for and apply a wound without actually dealing damage. Used for aggregate wounding power with pellet clouds
 /obj/item/bodypart/proc/painless_wound_roll(wounding_type, phantom_wounding_dmg, wound_bonus, bare_wound_bonus, sharpness=NONE)
+	#ifdef EVENTMODE
+	if(!GLOB.global_roster.enable_random_wounds)
+		return
+	#endif
 	if(!owner || phantom_wounding_dmg <= WOUND_MINIMUM_DAMAGE || wound_bonus == CANT_WOUND)
 		return
 


### PR DESCRIPTION
- Fixes Battle Royale to actually work, eliminate people on getting knocked unconscious/killed
- Disables station traits while eventmode is active
- Fixes knockout sound for BR eliminations
- Fixes spawn protection just being a holosign, now actually only allows respective teams
- Fixes godmode not working