### PR TITLE
Only allow spectators to vote in polls (scrying counts too)

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -134,6 +134,11 @@ SUBSYSTEM_DEF(vote)
 	return .
 
 /datum/controller/subsystem/vote/proc/submit_vote(vote)
+	#ifdef EVENTMODE
+	if(usr.stat != DEAD)
+		to_chat(usr, span_warning("Only ghosts and the dead may vote in event polls!"))
+		return FALSE
+	#endif
 	if(!mode)
 		return FALSE
 	if(CONFIG_GET(flag/no_dead_vote) && usr.stat == DEAD && !usr.client.holder)


### PR DESCRIPTION
Incase we don't want living participants to be taking part in votes that may decide their own fate.